### PR TITLE
Feature/node config update

### DIFF
--- a/examples/arduino/host/Host.ino
+++ b/examples/arduino/host/Host.ino
@@ -47,8 +47,7 @@ EspNowHost::OnApplicationMessage _on_application_message = [](EspNowHost::Messag
                                                               const uint8_t *message) {
   // Callback for new application messages.
   auto id = message[0];
-  Serial.println("Got message from 0x" + String(metadata.mac_address) + " with ID " +
-                 id); // + " rssi=" + String(metadata.rssi));
+  Serial.println("Got message from 0x" + String(metadata.mac_address) + " with ID " + id);
   switch (id) {
   case 0x01: {
     MyApplicationMessage *msg = (MyApplicationMessage *)message;
@@ -71,9 +70,9 @@ EspNowHost::FirmwareUpdateAvailable _firmware_update_available = [](uint64_t mac
   return std::nullopt;
 };
 
-EspNowHost::ConfigUpdateAvailable _config_update_available = [](uint64_t mac_address, uint16_t config_version) {
-  Serial.println(("_config_update_available start ver=" + std::to_string(config_version)).c_str());
-  if (config_version != 1) {
+EspNowHost::ConfigUpdateAvailable _config_update_available = [](uint64_t mac_address, uint16_t configuration_revision) {
+  Serial.println(("_config_update_available start ver=" + std::to_string(configuration_revision)).c_str());
+  if (configuration_revision != 1) {
     EspNowConfigEnvelope env;
     env.version = 1;
     MyConfigMessageV1 cfg;

--- a/examples/arduino/host_with_configuration/Host.ino
+++ b/examples/arduino/host_with_configuration/Host.ino
@@ -1,3 +1,4 @@
+#include "shared/esp-now-structs.h"
 #include <Arduino.h>
 #include <EspNowCrypt.h>
 #include <EspNowHost.h>
@@ -13,6 +14,10 @@ struct MyApplicationMessage {
 struct MySecondApplicationMessage {
   uint8_t id = 0x02;
   double temperature;
+};
+struct MyConfigMessageV1 {
+  uint32_t sleep_seconds;
+  uint8_t foo;
 };
 #pragma pack(0)
 
@@ -54,12 +59,32 @@ EspNowHost::OnApplicationMessage _on_application_message = [](EspNowHost::Messag
     Serial.println("MyApplicationMessage::temperature: " + String(msg->temperature));
     break;
   }
+  default: {
+    Serial.println("Unknown message id: " + String(id));
+  }
   }
 };
 
 EspNowHost::FirmwareUpdateAvailable _firmware_update_available = [](uint64_t mac_address, uint32_t firmware_version) {
   // Callback where we can indicate if there is a new firmware available.
   return std::nullopt;
+};
+
+EspNowHost::ConfigurationUpdateAvailable _config_update_available = [](uint64_t mac_address,
+                                                                       uint16_t configuration_revision) {
+  Serial.println(("_config_update_available start ver=" + std::to_string(configuration_revision)).c_str());
+  if (configuration_revision != 1) {
+    EspNowConfigEnvelope env;
+    env.version = 1;
+    MyConfigMessageV1 cfg;
+    cfg.sleep_seconds = 30;
+    cfg.foo = 111;
+    env.length = sizeof(MyConfigMessageV1);
+    memcpy(&env.payload, &cfg, env.length);
+    return (std::optional<EspNowConfigEnvelope>)env;
+  }
+
+  return (std::optional<EspNowConfigEnvelope>)std::nullopt;
 };
 
 EspNowHost::OnLog _on_log = [](const std::string message, const esp_log_level_t log_level) {
@@ -98,7 +123,7 @@ EspNowHost::OnLog _on_log = [](const std::string message, const esp_log_level_t 
 
 EspNowCrypt _esp_now_crypt(esp_now_encryption_key, esp_now_encryption_secret);
 EspNowHost _esp_now_host(_esp_now_crypt, EspNowHost::WiFiInterface::STA, _on_new_message, _on_application_message,
-                         _firmware_update_available, NULL, _on_log);
+                         _firmware_update_available, _config_update_available, _on_log);
 
 void setup() {
   Serial.begin(115200);
@@ -114,6 +139,8 @@ void setup() {
   Serial.println("have wifi");
   Serial.print("IP number: ");
   Serial.println(WiFi.localIP());
+  Serial.print("Channel: ");
+  Serial.println(WiFi.channel());
 
   pinMode(LED_PIN, OUTPUT);
   digitalWrite(LED_PIN, HIGH);

--- a/examples/arduino/node_with_configuration/Node.ino
+++ b/examples/arduino/node_with_configuration/Node.ino
@@ -1,0 +1,136 @@
+#include <Arduino.h>
+#include <EspNowCrypt.h>
+#include <EspNowNode.h>
+#include <EspNowPreferences.h>
+#include <esp_crt_bundle.h>
+
+#define MICROSECONDS_PER_SECOND 1000000LL
+#define DEFAULT_SLEEP_TIME_US (MICROSECONDS_PER_SECOND * 60LL) // 60 seconds
+
+#define FIRMWARE_VERSION 90201
+
+// These structs are the application messages shared across the host and node
+// device.
+#pragma pack(1)
+struct MyApplicationMessage {
+  uint8_t id = 0x01;
+  bool open;
+};
+struct MySecondApplicationMessage {
+  uint8_t id = 0x02;
+  double temperature;
+};
+struct MyConfigMessageV1 {
+  uint32_t sleep_seconds; // how long the node should deep-sleep
+  uint8_t foo;            // some other config value, not used in this example
+};
+#pragma pack(0)
+
+// Encyption key used for our own packet encryption (GCM).
+// We are not using the esp-now encryption due to the peer limitation.
+// The key should be the same for both the host and the node.
+const char esp_now_encryption_key[] = "0123456789ABCDEF"; // Must be exact 16 bytes long. \0 does not count.
+
+// Used to validate the integrity of the messages.
+// The secret should be the same for both the host and the node.
+const char esp_now_encryption_secret[] = "01234567"; // Must be exact 8 bytes long. \0 does not count.
+
+unsigned long _turn_of_led_at_ms = 0;
+
+EspNowNode::OnLog _on_log = [](const std::string message, const esp_log_level_t log_level) {
+  // Callback for logging. Can be omitted.
+  if (log_level == ESP_LOG_NONE) {
+    return; // Weird flex, but ok
+  }
+
+  std::string level;
+  switch (log_level) {
+  case ESP_LOG_NONE:
+    level = "none";
+    break;
+  case ESP_LOG_ERROR:
+    level = "error";
+    break;
+  case ESP_LOG_WARN:
+    level = "warning";
+    break;
+  case ESP_LOG_INFO:
+    level = "info";
+    break;
+  case ESP_LOG_DEBUG:
+    level = "debug";
+    break;
+  case ESP_LOG_VERBOSE:
+    level = "verbose";
+    break;
+  default:
+    level = "unknown";
+    break;
+  }
+  Serial.println(("EspNowNode (" + level + "): " + message).c_str());
+};
+
+EspNowNode::OnStatus _on_status = [](EspNowNode::Status status) {
+  switch (status) {
+  case EspNowNode::Status::HOST_DISCOVERY_STARTED:
+    break;
+  case EspNowNode::Status::HOST_DISCOVERY_SUCCESSFUL:
+    break;
+  case EspNowNode::Status::HOST_DISCOVERY_FAILED:
+    break;
+  case EspNowNode::Status::INVALID_HOST:
+    break;
+  case EspNowNode::Status::FIRMWARE_UPDATE_STARTED:
+    break;
+  case EspNowNode::Status::FIRMWARE_UPDATE_SUCCESSFUL:
+    break;
+  case EspNowNode::Status::FIRMWARE_UPDATE_FAILED:
+    break;
+  case EspNowNode::Status::FIRMWARE_UPDATE_WIFI_SETUP_FAILED:
+    break;
+  }
+};
+
+EspNowPreferences _esp_now_preferences;
+EspNowCrypt _esp_now_crypt(esp_now_encryption_key, esp_now_encryption_secret);
+EspNowNode _esp_now_node(_esp_now_crypt, _esp_now_preferences, FIRMWARE_VERSION, _on_status, _on_log,
+                         arduino_esp_crt_bundle_attach);
+
+void setup() {
+  Serial.begin(115200);
+
+  _esp_now_preferences.initalizeNVS();
+
+  MyConfigMessageV1 configuration;
+  bool config_loaded = false;
+  if (_esp_now_preferences.getConfigData((uint8_t *)&configuration, (uint8_t)sizeof(MyConfigMessageV1))) {
+    config_loaded = true;
+    _on_log(("loaded sleep_seconds=" + std::to_string(configuration.sleep_seconds) +
+             " foo=" + std::to_string(configuration.foo))
+                .c_str(),
+            ESP_LOG_DEBUG);
+  } else {
+    _on_log("no config loaded", ESP_LOG_INFO);
+  }
+
+  // Setup node, send message, and then go to sleep.
+  if (_esp_now_node.setup()) {
+    MySecondApplicationMessage message;
+    message.temperature = 25.6;
+    _esp_now_node.sendMessage(&message, sizeof(MySecondApplicationMessage));
+  } else {
+    _on_log("setup failed", ESP_LOG_ERROR);
+  }
+
+  uint32_t sleep_time_us = DEFAULT_SLEEP_TIME_US;
+  if (config_loaded) {
+    sleep_time_us = configuration.sleep_seconds * MICROSECONDS_PER_SECOND;
+  }
+
+  _on_log(("sleeping for " + std::to_string(sleep_time_us / (MICROSECONDS_PER_SECOND)) + " seconds").c_str(),
+          ESP_LOG_INFO);
+
+  esp_deep_sleep(sleep_time_us);
+}
+
+void loop() {}

--- a/src/host/EspNowHost.h
+++ b/src/host/EspNowHost.h
@@ -9,6 +9,8 @@
 #include <map>
 #include <optional>
 #include <string>
+#include "impl/esp-now-structs.h"
+
 
 /**
  * @brief ESP Now Network: Host
@@ -73,6 +75,9 @@ public:
   typedef std::function<std::optional<FirmwareUpdate>(uint64_t mac_address, uint32_t firmware_version)>
       FirmwareUpdateAvailable;
 
+  typedef std::function<std::optional<ConfigEnvelope>(uint64_t mac_address, uint32_t config_version)>
+      ConfigUpdateAvailable;
+
   enum class WiFiInterface {
     AP,  // Use the Access Point interface for ESP-NOW.
     STA, // Use the Station/Client interface for ESP-NOW.
@@ -94,8 +99,12 @@ public:
    * and its firmware version have new firmware.
    * @param on_log callback when the host want to log something.
    */
-  EspNowHost(EspNowCrypt &crypt, WiFiInterface wifi_interface, OnNewMessage on_new_message,
-             OnApplicationMessage on_application_message, FirmwareUpdateAvailable firwmare_update = {},
+  EspNowHost(EspNowCrypt &crypt, 
+             WiFiInterface wifi_interface, 
+             OnNewMessage on_new_message,
+             OnApplicationMessage on_application_message, 
+             FirmwareUpdateAvailable firwmare_update = {},
+             ConfigUpdateAvailable config_update = {},
              OnLog on_log = {});
 
 public:
@@ -137,6 +146,7 @@ private:
   OnLog _on_log;
   OnNewMessage _on_new_message;
   FirmwareUpdateAvailable _firwmare_update;
+  ConfigUpdateAvailable _config_update;
   OnApplicationMessage _on_application_message;
 };
 

--- a/src/host/EspNowHost.h
+++ b/src/host/EspNowHost.h
@@ -9,8 +9,8 @@
 #include <map>
 #include <optional>
 #include <string>
-#include "impl/esp-now-structs.h"
 
+struct EspNowConfigEnvelope;
 
 /**
  * @brief ESP Now Network: Host
@@ -74,8 +74,8 @@ public:
    */
   typedef std::function<std::optional<FirmwareUpdate>(uint64_t mac_address, uint32_t firmware_version)>
       FirmwareUpdateAvailable;
-
-  typedef std::function<std::optional<ConfigEnvelope>(uint64_t mac_address, uint32_t config_version)>
+  
+  typedef std::function<std::optional<EspNowConfigEnvelope>(uint64_t mac_address, uint8_t config_version)>
       ConfigUpdateAvailable;
 
   enum class WiFiInterface {
@@ -126,7 +126,7 @@ private:
 
   void handleQueuedMessage(uint8_t *mac_addr, uint8_t *data);
   void handleDiscoveryRequest(uint8_t *mac_addr, uint32_t discovery_challenge);
-  void handleChallengeRequest(uint8_t *mac_addr, uint32_t challenge_challenge, uint32_t firmware_version);
+  void handleChallengeRequest(uint8_t *mac_addr, uint32_t challenge_challenge, uint32_t firmware_version, uint16_t config_version);
 
   void sendMessageToTemporaryPeer(uint8_t *mac_addr, void *message, size_t length);
 

--- a/src/host/EspNowHost.h
+++ b/src/host/EspNowHost.h
@@ -74,7 +74,7 @@ public:
    */
   typedef std::function<std::optional<FirmwareUpdate>(uint64_t mac_address, uint32_t firmware_version)>
       FirmwareUpdateAvailable;
-  
+
   typedef std::function<std::optional<EspNowConfigEnvelope>(uint64_t mac_address, uint8_t config_version)>
       ConfigUpdateAvailable;
 
@@ -99,13 +99,9 @@ public:
    * and its firmware version have new firmware.
    * @param on_log callback when the host want to log something.
    */
-  EspNowHost(EspNowCrypt &crypt, 
-             WiFiInterface wifi_interface, 
-             OnNewMessage on_new_message,
-             OnApplicationMessage on_application_message, 
-             FirmwareUpdateAvailable firwmare_update = {},
-             ConfigUpdateAvailable config_update = {},
-             OnLog on_log = {});
+  EspNowHost(EspNowCrypt &crypt, WiFiInterface wifi_interface, OnNewMessage on_new_message,
+             OnApplicationMessage on_application_message, FirmwareUpdateAvailable firwmare_update = {},
+             ConfigUpdateAvailable config_update = {}, OnLog on_log = {});
 
 public:
   /**
@@ -126,7 +122,8 @@ private:
 
   void handleQueuedMessage(uint8_t *mac_addr, uint8_t *data);
   void handleDiscoveryRequest(uint8_t *mac_addr, uint32_t discovery_challenge);
-  void handleChallengeRequest(uint8_t *mac_addr, uint32_t challenge_challenge, uint32_t firmware_version, uint16_t config_version);
+  void handleChallengeRequest(uint8_t *mac_addr, uint32_t challenge_challenge, uint32_t firmware_version,
+                              uint16_t config_version);
 
   void sendMessageToTemporaryPeer(uint8_t *mac_addr, void *message, size_t length);
 

--- a/src/host/impl/EspNowHost.cpp
+++ b/src/host/impl/EspNowHost.cpp
@@ -236,14 +236,14 @@ void EspNowHost::handleChallengeRequest(uint8_t *mac_addr, uint32_t challenge_ch
               " len=" + std::to_string(metadata->header.length),
           ESP_LOG_INFO);
 
-      EspNowChallengeConfigResponseV1 message;
+      EspNowChallengeConfigurationResponseV1 message;
       message.challenge_challenge = challenge_challenge;
       message.revision = metadata->header.revision;
       message.length = metadata->header.length;
 
-      uint8_t buf[sizeof(EspNowChallengeConfigResponseV1) + metadata->header.length];
-      memcpy(buf, &message, sizeof(EspNowChallengeConfigResponseV1));
-      memcpy(buf + sizeof(EspNowChallengeConfigResponseV1), metadata->payload, metadata->header.length);
+      uint8_t buf[sizeof(EspNowChallengeConfigurationResponseV1) + metadata->header.length];
+      memcpy(buf, &message, sizeof(EspNowChallengeConfigurationResponseV1));
+      memcpy(buf + sizeof(EspNowChallengeConfigurationResponseV1), metadata->payload, metadata->header.length);
 
       sendMessageToTemporaryPeer(mac_addr, &buf, sizeof(buf));
       delete[](uint8_t *) metadata->payload;

--- a/src/host/impl/EspNowHost.cpp
+++ b/src/host/impl/EspNowHost.cpp
@@ -246,7 +246,7 @@ void EspNowHost::handleChallengeRequest(uint8_t *mac_addr, uint32_t challenge_ch
       memcpy(buf + sizeof(EspNowChallengeConfigResponseV1), metadata->payload, metadata->header.length);
 
       sendMessageToTemporaryPeer(mac_addr, &buf, sizeof(buf));
-      delete metadata->payload;
+      delete[](uint8_t *) metadata->payload;
       return;
     }
   }

--- a/src/host/impl/EspNowHost.cpp
+++ b/src/host/impl/EspNowHost.cpp
@@ -236,7 +236,6 @@ void EspNowHost::handleChallengeRequest(uint8_t *mac_addr, uint32_t challenge_ch
           ESP_LOG_INFO);
       EspNowChallengeConfigResponseV1 message;
       message.challenge_challenge = challenge_challenge;
-    std:
       memcpy(&message.envelope, &metadata, sizeof(EspNowConfigEnvelope));
       sendMessageToTemporaryPeer(mac_addr, &message, sizeof(EspNowChallengeConfigResponseV1));
       return;

--- a/src/host/impl/EspNowHost.cpp
+++ b/src/host/impl/EspNowHost.cpp
@@ -55,15 +55,12 @@ void EspNowHost::esp_now_on_data_callback(const esp_now_recv_info_t *esp_now_inf
 }
 #endif
 
-EspNowHost::EspNowHost(EspNowCrypt &crypt, 
-                       EspNowHost::WiFiInterface wifi_interface, 
-                       OnNewMessage on_new_message,
-                       OnApplicationMessage on_application_message, 
-                       FirmwareUpdateAvailable firwmare_update,
-                       ConfigUpdateAvailable config_update,
-                       OnLog on_log)
+EspNowHost::EspNowHost(EspNowCrypt &crypt, EspNowHost::WiFiInterface wifi_interface, OnNewMessage on_new_message,
+                       OnApplicationMessage on_application_message, FirmwareUpdateAvailable firwmare_update,
+                       ConfigUpdateAvailable config_update, OnLog on_log)
     : _crypt(crypt), _wifi_interface(wifi_interface), _on_log(on_log), _on_new_message(on_new_message),
-      _firwmare_update(firwmare_update), _config_update(config_update), _on_application_message(on_application_message) {}
+      _firwmare_update(firwmare_update), _config_update(config_update),
+      _on_application_message(on_application_message) {}
 
 void EspNowHost::newMessageTask(void *pvParameters) {
   EspNowHost *_this = (EspNowHost *)pvParameters;
@@ -190,9 +187,8 @@ void EspNowHost::handleQueuedMessage(uint8_t *mac_addr, uint8_t *data) {
     EspNowChallengeRequestV1 *message = (EspNowChallengeRequestV1 *)data;
     auto firmware_version = message->firmware_version;
     auto config_version = message->config_version;
-    log("Got challenge request from 0x" + toHex(mac_address) +
-            ", firmware version: " + std::to_string(firmware_version) +
-            ", config version: " + std::to_string(config_version),
+    log("Got challenge request from 0x" + toHex(mac_address) + ", firmware version: " +
+            std::to_string(firmware_version) + ", config version: " + std::to_string(config_version),
         ESP_LOG_INFO);
     handleChallengeRequest(mac_addr, message->challenge_challenge, firmware_version, config_version);
     break;
@@ -212,7 +208,8 @@ void EspNowHost::handleDiscoveryRequest(uint8_t *mac_addr, uint32_t discovery_ch
   sendMessageToTemporaryPeer(mac_addr, &message, sizeof(EspNowDiscoveryResponseV1));
 }
 
-void EspNowHost::handleChallengeRequest(uint8_t *mac_addr, uint32_t challenge_challenge, uint32_t firmware_version, uint16_t config_version) {
+void EspNowHost::handleChallengeRequest(uint8_t *mac_addr, uint32_t challenge_challenge, uint32_t firmware_version,
+                                        uint16_t config_version) {
   uint64_t mac_address = macToMac(mac_addr);
 
   // Any firmware to update?
@@ -235,10 +232,12 @@ void EspNowHost::handleChallengeRequest(uint8_t *mac_addr, uint32_t challenge_ch
     log("checking for config_update", ESP_LOG_INFO);
     auto metadata = _config_update(mac_address, config_version);
     if (metadata) {
-      log("config update: version=" + std::to_string(metadata->version) + " len=" + std::to_string(metadata->length), ESP_LOG_INFO);
+      log("config update: version=" + std::to_string(metadata->version) + " len=" + std::to_string(metadata->length),
+          ESP_LOG_INFO);
       EspNowChallengeConfigResponseV1 message;
       message.challenge_challenge = challenge_challenge;
-      std:memcpy(&message.envelope, &metadata, sizeof(EspNowConfigEnvelope));
+    std:
+      memcpy(&message.envelope, &metadata, sizeof(EspNowConfigEnvelope));
       sendMessageToTemporaryPeer(mac_addr, &message, sizeof(EspNowChallengeConfigResponseV1));
       return;
     }

--- a/src/node/EspNowNode.h
+++ b/src/node/EspNowNode.h
@@ -211,6 +211,7 @@ private:
   OnStatus _on_status;
   EspNowCrypt &_crypt;
   esp_netif_t *_netif_sta;
+  uint16_t _config_version;
   uint32_t _firmware_version;
   bool _setup_successful = false;
   CrtBundleAttach _crt_bundle_attach;

--- a/src/node/EspNowNode.h
+++ b/src/node/EspNowNode.h
@@ -211,7 +211,7 @@ private:
   OnStatus _on_status;
   EspNowCrypt &_crypt;
   esp_netif_t *_netif_sta;
-  uint16_t _config_version;
+  uint16_t _configuration_revision;
   uint32_t _firmware_version;
   bool _setup_successful = false;
   CrtBundleAttach _crt_bundle_attach;

--- a/src/node/EspNowPreferences.h
+++ b/src/node/EspNowPreferences.h
@@ -35,6 +35,17 @@ public:
   bool espNowGetMacForHost(uint8_t *buffer) override;
 
   /**
+   * @brief Set the config envelope that contains the application-specific config data.
+   */
+  bool setConfig(EspNowConfigEnvelope *config_envelope) override;
+
+  /**
+   * @brief Get the config envelope that contains the application-specific config data.
+   * @param config_envelope the EspNowConfigEnvelope to copy the data into
+   */
+  bool getConfig(EspNowConfigEnvelope *config_envelope) override;
+
+  /**
    * @brief After setting variables, call this to commit/save.
    * @return true on success.
    */

--- a/src/node/EspNowPreferences.h
+++ b/src/node/EspNowPreferences.h
@@ -37,13 +37,16 @@ public:
   /**
    * @brief Set the config envelope that contains the application-specific config data.
    */
-  bool setConfig(EspNowConfigEnvelope *config_envelope) override;
+  bool setConfigHeader(ConfigurationHeader *configuration_header) override;
 
   /**
    * @brief Get the config envelope that contains the application-specific config data.
    * @param config_envelope the EspNowConfigEnvelope to copy the data into
    */
-  bool getConfig(EspNowConfigEnvelope *config_envelope) override;
+  bool getConfigHeader(ConfigurationHeader *configuration_header) override;
+
+  bool getConfigData(uint8_t *buffer, uint8_t length) override;
+  bool setConfigData(uint8_t *buffer, uint8_t length) override;
 
   /**
    * @brief After setting variables, call this to commit/save.

--- a/src/node/Preferences.h
+++ b/src/node/Preferences.h
@@ -2,6 +2,7 @@
 #define __ESP_NOW_I_PREFERENCES_H__
 
 #include <cstdint>
+#include "esp-now-config.h"
 
 namespace EspNowNetwork {
 
@@ -25,6 +26,9 @@ public:
    * @param return true if MAC was read successfully.
    */
   virtual bool espNowGetMacForHost(uint8_t *buffer) = 0;
+
+  virtual bool getConfig(EspNowConfigEnvelope *config_envelope) = 0;
+  virtual bool setConfig(EspNowConfigEnvelope *config_envelope) = 0;
 
   /**
    * @brief Commit any changes written.

--- a/src/node/Preferences.h
+++ b/src/node/Preferences.h
@@ -27,8 +27,11 @@ public:
    */
   virtual bool espNowGetMacForHost(uint8_t *buffer) = 0;
 
-  virtual bool getConfig(EspNowConfigEnvelope *config_envelope) = 0;
-  virtual bool setConfig(EspNowConfigEnvelope *config_envelope) = 0;
+  virtual bool getConfigHeader(ConfigurationHeader *configuration_header) = 0;
+  virtual bool setConfigHeader(ConfigurationHeader *configuration_header) = 0;
+
+  virtual bool getConfigData(uint8_t *buffer, uint8_t length) = 0;
+  virtual bool setConfigData(uint8_t *buffer, uint8_t length) = 0;
 
   /**
    * @brief Commit any changes written.

--- a/src/node/Preferences.h
+++ b/src/node/Preferences.h
@@ -1,8 +1,8 @@
 #ifndef __ESP_NOW_I_PREFERENCES_H__
 #define __ESP_NOW_I_PREFERENCES_H__
 
-#include <cstdint>
 #include "esp-now-config.h"
+#include <cstdint>
 
 namespace EspNowNetwork {
 

--- a/src/node/impl/EspNowNode.cpp
+++ b/src/node/impl/EspNowNode.cpp
@@ -280,7 +280,8 @@ bool EspNowNode::sendMessage(void *message, size_t message_size, int16_t retries
       }
       case MESSAGE_ID_CHALLENGE_CONFIG_RESPONSE_V1: {
         log("Got challenge update config response.", ESP_LOG_INFO);
-        EspNowChallengeConfigResponseV1 *response = (EspNowChallengeConfigResponseV1 *)decrypted_data.get();
+        EspNowChallengeConfigurationResponseV1 *response =
+            (EspNowChallengeConfigurationResponseV1 *)decrypted_data.get();
         // Validate the challenge for the challenge request/response pair
         if (response->challenge_challenge == request.challenge_challenge) {
           ConfigurationHeader configuration_header;
@@ -290,8 +291,8 @@ bool EspNowNode::sendMessage(void *message, size_t message_size, int16_t retries
 
           uint8_t buf[response->length]; // buffer to hold configuration data
 
-          // configuration data is at the end of the EspNowChallengeConfigResponseV1 message
-          memcpy(buf, decrypted_data.get() + sizeof(EspNowChallengeConfigResponseV1), response->length);
+          // configuration data is at the end of the EspNowChallengeConfigurationResponseV1 message
+          memcpy(buf, decrypted_data.get() + sizeof(EspNowChallengeConfigurationResponseV1), response->length);
           _preferences.setConfigData(buf, response->length);
           _preferences.commit();
           log("Saved config (version=" + std::to_string(configuration_header.revision) + " ). Restarting.",

--- a/src/shared/esp-now-config.h
+++ b/src/shared/esp-now-config.h
@@ -10,7 +10,7 @@
 struct EspNowConfigEnvelope {
   uint16_t version; // an ID that should be unique for each unique config/payload
   uint8_t length;   // length of the payload
-  uint8_t payload[150];
+  uint8_t payload[150]; // needs to fit within ESP NOW limit of 250 bytes, minus headers etc
 };
 
 #endif // __ESP_NOW_CONFIG_H__

--- a/src/shared/esp-now-config.h
+++ b/src/shared/esp-now-config.h
@@ -4,13 +4,11 @@
 #include <cstdint>
 
 /**
- * A container for the application-specific config data that is held within the payload.
- * The payload could be anything, like a string, or json, but is probably a struct for efficiency.
+ * @brief Basic configuration metadata.
  */
-struct EspNowConfigEnvelope {
-  uint16_t version; // an ID that should be unique for each unique config/payload
-  uint8_t length;   // length of the payload
-  uint8_t payload[150]; // needs to fit within ESP NOW limit of 250 bytes, minus headers etc
+struct ConfigurationHeader {
+  uint64_t revision;
+  uint8_t length;
 };
 
 #endif // __ESP_NOW_CONFIG_H__

--- a/src/shared/esp-now-config.h
+++ b/src/shared/esp-now-config.h
@@ -3,11 +3,11 @@
 
 /**
  * A container for the application-specific config data that is held within the payload.
- * The payload could be anything, like a string, or json, but is probably a struct for efficiency. 
+ * The payload could be anything, like a string, or json, but is probably a struct for efficiency.
  */
 struct EspNowConfigEnvelope {
-  uint16_t version;       // an ID that should be unique for each unique config/payload
-  uint8_t length;         // length of the payload
+  uint16_t version; // an ID that should be unique for each unique config/payload
+  uint8_t length;   // length of the payload
   uint8_t payload[150];
 };
 

--- a/src/shared/esp-now-config.h
+++ b/src/shared/esp-now-config.h
@@ -1,0 +1,14 @@
+#ifndef __ESP_NOW_CONFIG_H__
+#define __ESP_NOW_CONFIG_H__
+
+/**
+ * A container for the application-specific config data that is held within the payload.
+ * The payload could be anything, like a string, or json, but is probably a struct for efficiency. 
+ */
+struct EspNowConfigEnvelope {
+  uint16_t version;       // an ID that should be unique for each unique config/payload
+  uint8_t length;         // length of the payload
+  uint8_t payload[150];
+};
+
+#endif // __ESP_NOW_CONFIG_H__

--- a/src/shared/esp-now-config.h
+++ b/src/shared/esp-now-config.h
@@ -1,6 +1,8 @@
 #ifndef __ESP_NOW_CONFIG_H__
 #define __ESP_NOW_CONFIG_H__
 
+#include <cstdint>
+
 /**
  * A container for the application-specific config data that is held within the payload.
  * The payload could be anything, like a string, or json, but is probably a struct for efficiency.

--- a/src/shared/esp-now-structs.h
+++ b/src/shared/esp-now-structs.h
@@ -2,6 +2,7 @@
 #define __ESP_NOW_STRUCTURE_H__
 
 #include <cstdint>
+#include "esp-now-config.h"
 
 #define MESSAGE_ID_HEADER 0x03
 
@@ -48,6 +49,7 @@ struct EspNowDiscoveryResponseV1 {
 struct EspNowChallengeRequestV1 {
   uint8_t id = MESSAGE_ID_CHALLENGE_REQUEST_V1;
   uint32_t firmware_version;
+  uint16_t config_version;
   // The challenge that the host should send back/set in [EspNowChallengeResponseV1] or
   // [EspNowChallengeFirmwareResponseV1] reply.
   uint32_t challenge_challenge;
@@ -75,17 +77,10 @@ struct EspNowChallengeFirmwareResponseV1 {
   char md5[32];                 // MD5 hash of firmware. Does not include trailing \0
 };
 
-struct ConfigEnvelope {
-  uint16_t version;
-  uint8_t schema;
-  uint8_t length;
-  uint8_t *payload;
-};
-
 struct EspNowChallengeConfigResponseV1 {
   uint8_t id = MESSAGE_ID_CHALLENGE_CONFIG_RESPONSE_V1;
   uint32_t challenge_challenge; // Challenge from [EspNowChallengeRequestV1].
-  ConfigEnvelope envelope;
+  EspNowConfigEnvelope envelope;
 };
 
 

--- a/src/shared/esp-now-structs.h
+++ b/src/shared/esp-now-structs.h
@@ -49,7 +49,7 @@ struct EspNowDiscoveryResponseV1 {
 struct EspNowChallengeRequestV1 {
   uint8_t id = MESSAGE_ID_CHALLENGE_REQUEST_V1;
   uint32_t firmware_version;
-  uint16_t config_version;
+  uint16_t configuration_revision;
   // The challenge that the host should send back/set in [EspNowChallengeResponseV1] or
   // [EspNowChallengeFirmwareResponseV1] reply.
   uint32_t challenge_challenge;
@@ -80,7 +80,9 @@ struct EspNowChallengeFirmwareResponseV1 {
 struct EspNowChallengeConfigResponseV1 {
   uint8_t id = MESSAGE_ID_CHALLENGE_CONFIG_RESPONSE_V1;
   uint32_t challenge_challenge; // Challenge from [EspNowChallengeRequestV1].
-  EspNowConfigEnvelope envelope;
+  uint64_t revision;            // the revision ID of the configuration
+  uint8_t length;               // length of configuration data to be sent to Node
+  // The encrypted payload (the configuration data) is appended after this message, and is of length specified above.
 };
 
 #pragma pack(0)

--- a/src/shared/esp-now-structs.h
+++ b/src/shared/esp-now-structs.h
@@ -77,7 +77,7 @@ struct EspNowChallengeFirmwareResponseV1 {
   char md5[32];                 // MD5 hash of firmware. Does not include trailing \0
 };
 
-struct EspNowChallengeConfigResponseV1 {
+struct EspNowChallengeConfigurationResponseV1 {
   uint8_t id = MESSAGE_ID_CHALLENGE_CONFIG_RESPONSE_V1;
   uint32_t challenge_challenge; // Challenge from [EspNowChallengeRequestV1].
   uint64_t revision;            // the revision ID of the configuration

--- a/src/shared/esp-now-structs.h
+++ b/src/shared/esp-now-structs.h
@@ -11,6 +11,7 @@
 #define MESSAGE_ID_CHALLENGE_REQUEST_V1 0xDA
 #define MESSAGE_ID_CHALLENGE_RESPONSE_V1 0xDB
 #define MESSAGE_ID_CHALLENGE_FIRMWARE_RESPONSE_V1 0xDC
+#define MESSAGE_ID_CHALLENGE_CONFIG_RESPONSE_V1 0xDD
 
 #pragma pack(1)
 
@@ -73,6 +74,20 @@ struct EspNowChallengeFirmwareResponseV1 {
   char url[96];                 // url where to find firmware binary. Note the max file path.
   char md5[32];                 // MD5 hash of firmware. Does not include trailing \0
 };
+
+struct ConfigEnvelope {
+  uint16_t version;
+  uint8_t schema;
+  uint8_t length;
+  uint8_t *payload;
+};
+
+struct EspNowChallengeConfigResponseV1 {
+  uint8_t id = MESSAGE_ID_CHALLENGE_CONFIG_RESPONSE_V1;
+  uint32_t challenge_challenge; // Challenge from [EspNowChallengeRequestV1].
+  ConfigEnvelope envelope;
+};
+
 
 #pragma pack(0)
 

--- a/src/shared/esp-now-structs.h
+++ b/src/shared/esp-now-structs.h
@@ -1,8 +1,8 @@
 #ifndef __ESP_NOW_STRUCTURE_H__
 #define __ESP_NOW_STRUCTURE_H__
 
-#include <cstdint>
 #include "esp-now-config.h"
+#include <cstdint>
 
 #define MESSAGE_ID_HEADER 0x03
 
@@ -82,7 +82,6 @@ struct EspNowChallengeConfigResponseV1 {
   uint32_t challenge_challenge; // Challenge from [EspNowChallengeRequestV1].
   EspNowConfigEnvelope envelope;
 };
-
 
 #pragma pack(0)
 


### PR DESCRIPTION
Adds the ability for a Host to remotely configure a Node.  When the Node is about to send a message, it sends a "challenge" message to the Host first and includes its firmware version, and the Host may respond with the details for a firmware update.  This PR adds the Node's config version to the challenge request, so the Host has the option to return a new configuration to the Node as part of a challenge response.

The configuration is application-specific, e.g.

- the length of time the Node should sleep
- how many samples the Node should take of an environmental sensor before averaging them
- how long the Node should ignore signals from a PIR sensor after it has been triggered

EspNowNetwork already supports "generic" firmware, that can be the same for multiple Nodes.  This PR allows Nodes to run generic firmware, but to fetch a potentially-Node-specific config from the Host.

